### PR TITLE
fix: remove duplicate logger handler and fix README imports

### DIFF
--- a/Custom_logger.py
+++ b/Custom_logger.py
@@ -31,10 +31,6 @@ console_handler = logging.StreamHandler()
 console_handler.setFormatter(console_formatter)
 logger.addHandler(console_handler)
 
-console_formatter = logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
-console_handler.setFormatter(console_formatter)
-logger.addHandler(console_handler)
-
 # -------------------------------
 # File handler with rotation
 # -------------------------------

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ playwright install chromium
 
 ```python
 import asyncio
-from BrowserManager import BrowserManager
+from src.BrowserManager import BrowserManager
 from src.WhatsApp.login import Login
 from src.WhatsApp.chat_processor import ChatProcessor
 from src.WhatsApp.web_ui_config import WebSelectorConfig
@@ -92,7 +92,7 @@ asyncio.run(main())
 
 ```python
 import asyncio
-from BrowserManager import BrowserManager
+from src.BrowserManager import BrowserManager
 from src.WhatsApp.login import Login
 from src.WhatsApp.chat_processor import ChatProcessor
 from src.WhatsApp.message_processor import MessageProcessor


### PR DESCRIPTION
## What does this PR do?
1. **Fixed duplicate logger handler bug** - [Custom_logger.py](cci:7://file:///c:/Users/kshit/.gemini/antigravity/playground/silver-expanse/tweakio-sdk/Custom_logger.py:0:0-0:0) was adding the same console handler twice, causing duplicate log messages
2. **Fixed README.md imports** - Corrected `from BrowserManager` to `from src.BrowserManager` in Quick Start examples


## AI Disclosure
- [x] This PR includes AI-generated code (Claude/GPT/Copilot)
- [ ] This PR is fully human-written

## Testing
- [x] Verified logger no longer produces duplicate messages
- [x] Verified import paths match codebase structure
