### PR TITLE
OSCG26_chore: remove additional unused dependencies (marshmallow, orjson)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,8 +46,6 @@ language-tags==1.2.0
 loguru==0.7.3
 lxml==6.0.2
 markdown-it-py==4.0.0
-marshmallow==4.0.1
-marshmallow-union==0.1.15.post1
 maxminddb==2.8.2
 mccabe==0.7.0
 mdurl==0.1.2
@@ -55,7 +53,6 @@ multivolumefile==0.2.3
 nh3==0.3.0
 numpy==2.3.3
 orderly-set==5.5.0
-orjson==3.11.3
 pillow==11.3.0
 platformdirs==4.4.0
 playwright==1.55.0


### PR DESCRIPTION
- Remove marshmallow (4.0.1) - not imported or used
- Remove marshmallow-union (0.1.15.post1) - not imported or used
- Remove orjson (3.11.3) - using Python's standard json library instead

This follows up on the previous PR that removed Django and aiohttp families.