### PR TITLE
feat: rename to CamouChat, add per-profile encryption key management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,15 +3,49 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "tweakio-sdk"
-version = "0.1.5"
-description = "Tweakio-SDK: WhatsApp automation Python library with anti-detection, async storage, and production-grade architecture"
+name = "camouchat"
+version = "0.6"
+description = "CamouChat: Anti-detection WhatsApp automation SDK with end-to-end encrypted storage, async SQLite/PostgreSQL, per-profile sandboxing, and human-like browser behaviour"
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "MIT" }
 
 authors = [{ name = "BITS-Rohit", email = "rohitguptaradheradhe123@gmail.com" }]
 maintainers = [{ name = "BITS-Rohit", email = "rohitguptaradheradhe123@gmail.com" }]
+
+keywords = [
+    "whatsapp",
+    "whatsapp-automation",
+    "whatsapp-bot",
+    "whatsapp-web",
+    "playwright",
+    "camoufox",
+    "anti-detection",
+    "browser-automation",
+    "encrypted-storage",
+    "aes-256",
+    "async",
+    "sqlite",
+    "postgresql",
+    "camouchat"
+]
+
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Communications :: Chat",
+    "Topic :: Internet :: WWW/HTTP :: Browsers",
+    "Topic :: Security :: Cryptography",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Framework :: AsyncIO",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Natural Language :: English",
+]
 
 dependencies = [
     "playwright>=1.40.0",
@@ -20,6 +54,7 @@ dependencies = [
     "cryptography>=41.0.0",
     "colorlog>=6.10.1",
     "sqlalchemy>=2.0.48",
+    "aiosqlite>=0.19.0",
     "browserforge>=1.2.4",
     "platformdirs>=4.0.0",
     "filelock>=3.13.0"
@@ -38,8 +73,10 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/BITS-Rohit/tweakio-sdk"
-Repository = "https://github.com/BITS-Rohit/tweakio-sdk"
+Homepage = "https://github.com/BITS-Rohit/camouchat"
+Repository = "https://github.com/BITS-Rohit/camouchat"
+"Bug Tracker" = "https://github.com/BITS-Rohit/camouchat/issues"
+Changelog = "https://github.com/BITS-Rohit/camouchat/releases"
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,7 @@
-from setuptools import setup, find_packages
+"""
+setup.py — legacy shim kept for editable/compatibility installs.
+All authoritative metadata lives in pyproject.toml.
+"""
+from setuptools import setup
 
-setup(
-    name="tweakio-SDK",
-    version="0.1.4",
-    description="High-performance, anti-detection WhatsApp automation SDK. Features async SQLite storage, rate limiting, and human-like interaction loops.",
-    author="Rohit",
-    author_email="keepquit000@gmail.com",  # Update with actual email if known, else leave blank or placeholder
-    packages=find_packages(),
-    py_modules=[
-        "ChatLoader",
-        "MessageProcessor", 
-        "Extra", 
-        "Storage", 
-        "directory", 
-        "Errors", 
-        "Reply", 
-        "Shared_Resources", 
-        "login", 
-        "selector_config", 
-        "unread_handler", 
-        "_Humanize", 
-        "_Media"
-    ],
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "Framework :: Playwright",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-    ],
-    python_requires=">=3.8", install_requires=['playwright']
-)
-
+setup()

--- a/src/BrowserManager/profile_manager.py
+++ b/src/BrowserManager/profile_manager.py
@@ -2,7 +2,8 @@ import json
 import os
 import shutil
 import signal
-from datetime import datetime
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import List, Optional, Dict
 
 from src.directory import DirectoryManager
@@ -12,28 +13,38 @@ from src.BrowserManager.profile_info import ProfileInfo
 
 
 class ProfileManager:
-    """Manager/Entry point for login & profiles creation.
+    """Manager / entry point for profile creation, activation, and key management.
+
+    Each profile is a sandboxed directory containing:
+    - metadata.json   : profile config & encryption metadata (no raw key)
+    - encryption.key  : base64-encoded AES-256 key (only present when encryption enabled)
+    - messages.db     : SQLAlchemy database
+    - fingerprint.pkl : browser fingerprint
+    - cache/, media/  : auxiliary profile data
     """
 
-    # p_count is runtime only & class variable
     p_count: int = 0
 
-    def __init__(self, app_name: str = "tweakio"):
+    def __init__(self, app_name: str = "CamouChat"):
         self.app_name = app_name
         self.directory = DirectoryManager(app_name)
 
-    def _generate_metadata(self, platform: Platform, profile_id: str) -> dict:
-        now = datetime.now().isoformat()
 
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _generate_metadata(self, platform: Platform, profile_id: str) -> dict:
+        now = datetime.now(timezone.utc).isoformat()
         return {
             "profile_id": profile_id,
             "platform": platform,
-            "version": "0.1.6",
+            "version": "0.6",
+
             "created_at": now,
             "last_used": now,
             "paths": {
                 "profile_dir": str(self.directory.get_profile_dir(platform, profile_id)),
-
                 "fingerprint_file": "fingerprint.pkl",
                 "cache_dir": "cache",
                 "media_dir": "media",
@@ -41,17 +52,35 @@ class ProfileManager:
                 "media_videos": "media/videos",
                 "media_voice": "media/voice",
                 "database_file": "messages.db",
-                "media_documents": "media/documents"
+                "media_documents": "media/documents",
             },
-            "encryption": {},
-
-
+            # Non-secret encryption metadata only.
+            # The actual key lives in encryption.key — NOT here.
+            "encryption": {
+                "enabled": False,
+                "algorithm": "AES-256-GCM",
+                "key_file": "encryption.key",   # relative path inside profile_dir
+                "created_at": None,              # set when enable_encryption() is called
+            },
             "status": {
                 "is_active": False,
                 "last_active_pid": None,
-                "lock_file": ".lock"
-            }
+                "lock_file": ".lock",
+            },
         }
+
+    def _read_metadata(self, platform: Platform, profile_id: str) -> dict:
+        profile_dir = self.directory.get_profile_dir(platform, profile_id)
+        metadata_file = profile_dir / "metadata.json"
+        if not metadata_file.exists():
+            raise ValueError(f"Profile metadata not found for '{profile_id}' on '{platform}'.")
+        with open(metadata_file) as f:
+            return json.load(f)
+
+    def _write_metadata(self, platform: Platform, profile_id: str, data: dict) -> None:
+        profile_dir = self.directory.get_profile_dir(platform, profile_id)
+        with open(profile_dir / "metadata.json", "w") as f:
+            json.dump(data, f, indent=4)
 
     @classmethod
     def __inc__(cls):
@@ -66,17 +95,17 @@ class ProfileManager:
     def __p_count__(cls):
         return cls.p_count
 
+    # ------------------------------------------------------------------
+    # Profile lifecycle
+    # ------------------------------------------------------------------
+
     def create_profile(self, platform: Platform, profile_id: str) -> ProfileInfo:
-        """
-        creates if not exists else return back exists one
-        """
+        """Create a new profile; returns the existing one if already present."""
         profile_dir = self.directory.get_profile_dir(platform, profile_id)
 
-        # If already exists → return loaded profile
         if profile_dir.exists():
             return self.get_profile(platform, profile_id)
 
-        # Create directory structure
         profile_dir.mkdir(parents=True, exist_ok=True)
 
         self.directory.get_cache_dir(platform, profile_id)
@@ -88,74 +117,186 @@ class ProfileManager:
         (profile_dir / "fingerprint.pkl").write_bytes(b"")
 
         metadata = self._generate_metadata(platform, profile_id)
-
-        with open(profile_dir / "metadata.json", "w") as f:
-            json.dump(metadata, f, indent=4)
+        self._write_metadata(platform, profile_id, metadata)
 
         return ProfileInfo.from_metadata(metadata, self.directory)
 
     def get_profile(self, platform: Platform, profile_id: str) -> ProfileInfo:
-        """Returns profile info"""
-        profile_dir = self.directory.get_profile_dir(platform, profile_id)
-        metadata_file = profile_dir / "metadata.json"
-
-        if not metadata_file.exists():
-            raise ValueError("Profile metadata not found.")
-
-        with open(metadata_file) as f:  # default in read mode
-            metadata = json.load(f)
-
+        """Return profile info for an existing profile."""
+        metadata = self._read_metadata(platform, profile_id)
         return ProfileInfo.from_metadata(metadata, self.directory)
 
     def is_profile_exists(self, platform: Platform, profile_id: str) -> bool:
-        """Checks if profile exists or not."""
+        """Check whether a profile directory exists."""
         platform_dir = self.directory.get_platform_dir(platform)
-
         if not platform_dir.exists():
             return False
-
         profile_path = platform_dir / profile_id
         return profile_path.exists() and profile_path.is_dir()
 
     def list_profiles(self, platform: Optional[Platform] = None) -> Dict[str, List[str]]:
         """
-        If platform is provided -> returns {platform: [profiles]}
-        If not provided -> returns {platform1: [...], platform2: [...]}
+        List profiles.
+
+        - If platform is provided → returns {platform: [profile_ids]}
+        - If not provided → returns {platform1: [...], platform2: [...], ...}
         """
-        # converted to dict for more structured, can be used by other codebase
         results: Dict[str, List[str]] = {}
 
         if platform:
             platform_dir = self.directory.get_platform_dir(platform)
-
             if platform_dir.exists():
-                results[platform] = [
-                    p.name for p in platform_dir.iterdir() if p.is_dir()
-                ]
+                results[platform] = [p.name for p in platform_dir.iterdir() if p.is_dir()]
         else:
             for plat in self.directory.platforms_dir.iterdir():
                 if plat.is_dir():
                     results[plat.name] = [
-                        profile.name
-                        for profile in plat.iterdir()
-                        if profile.is_dir()
+                        profile.name for profile in plat.iterdir() if profile.is_dir()
                     ]
 
         return results
+
+    # ------------------------------------------------------------------
+    # Encryption key management
+    # ------------------------------------------------------------------
+
+    def enable_encryption(self, platform: Platform, profile_id: str) -> bytes:
+        """
+        Generate a fresh AES-256 key for this profile, persist it to
+        ``encryption.key``, and mark encryption as enabled in metadata.
+
+        Returns the raw 32-byte key so the caller can hand it straight
+        to ``MessageProcessor`` without ever having to re-read the file
+        in the same session.
+
+        Raises:
+            ValueError: If encryption is already enabled for this profile.
+
+        Example::
+
+            key = manager.enable_encryption(Platform.WHATSAPP, "my_profile")
+            processor = MessageProcessor(..., encryption_key=key)
+        """
+        from src.Encryption import KeyManager
+
+        metadata = self._read_metadata(platform, profile_id)
+
+        if metadata["encryption"].get("enabled"):
+            raise ValueError(
+                f"Encryption is already enabled for profile '{profile_id}'. "
+                "Disable it first before re-enabling."
+            )
+
+        # Generate a random 32-byte key (no password derivation — the key file IS the secret)
+        raw_key: bytes = KeyManager.generate_random_key()
+        encoded_key: str = KeyManager.encode_key_for_storage(raw_key)
+
+        # Write key file with strict permissions (owner read-only)
+        key_file: Path = self.directory.get_key_file_path(platform, profile_id)
+        key_file.write_text(encoded_key, encoding="utf-8")
+        try:
+            os.chmod(key_file, 0o600)   # -rw------- on Linux/macOS
+        except OSError:
+            pass    # Windows: chmod is a no-op, skip silently
+
+        # Update metadata encryption block — NO key material stored here
+        metadata["encryption"]["enabled"] = True
+        metadata["encryption"]["created_at"] = datetime.now(timezone.utc).isoformat()
+        self._write_metadata(platform, profile_id, metadata)
+
+        return raw_key
+
+    def get_key(self, platform: Platform, profile_id: str) -> bytes:
+        """
+        Load and return the raw AES-256 key for this profile.
+
+        Use this when resuming a session to get the key back for
+        ``MessageProcessor`` or ``MessageDecryptor``.
+
+        Raises:
+            ValueError: If encryption is not enabled for this profile.
+            FileNotFoundError: If the key file is missing (profile corruption).
+
+        Example::
+
+            key = manager.get_key(Platform.WHATSAPP, "my_profile")
+            decryptor = MessageDecryptor(key)
+            plaintext = decryptor.decrypt_message(nonce_bytes, cipher_bytes)
+        """
+        from src.Encryption import KeyManager
+
+        metadata = self._read_metadata(platform, profile_id)
+
+        if not metadata["encryption"].get("enabled"):
+            raise ValueError(
+                f"Encryption is not enabled for profile '{profile_id}'. "
+                "Call enable_encryption() first."
+            )
+
+        key_file: Path = self.directory.get_key_file_path(platform, profile_id)
+
+        if not key_file.exists():
+            raise FileNotFoundError(
+                f"Encryption key file missing for profile '{profile_id}' "
+                f"(expected: {key_file}). The profile may be corrupted."
+            )
+
+        encoded_key = key_file.read_text(encoding="utf-8").strip()
+        return KeyManager.decode_key_from_storage(encoded_key)
+
+    def is_encryption_enabled(self, platform: Platform, profile_id: str) -> bool:
+        """Return True if encryption is currently enabled for this profile."""
+        metadata = self._read_metadata(platform, profile_id)
+        return bool(metadata["encryption"].get("enabled", False))
+
+    def disable_encryption(self, platform: Platform, profile_id: str) -> None:
+        """
+        Disable encryption for this profile and wipe the key file.
+
+        .. warning::
+            This permanently deletes the encryption key. Any messages already
+            stored as ciphertext in the database will be irrecoverable.
+            Decrypt all messages *before* calling this if you need the plaintext.
+
+        Raises:
+            ValueError: If encryption is not enabled for this profile.
+        """
+        metadata = self._read_metadata(platform, profile_id)
+
+        if not metadata["encryption"].get("enabled"):
+            raise ValueError(
+                f"Encryption is not enabled for profile '{profile_id}'."
+            )
+
+        # Securely remove the key file
+        key_file: Path = self.directory.get_key_file_path(platform, profile_id)
+        if key_file.exists():
+            # Overwrite with zeros before unlinking to reduce forensic recoverability
+            key_size = key_file.stat().st_size
+            key_file.write_bytes(b"\x00" * key_size)
+            key_file.unlink()
+
+        # Reset metadata
+        metadata["encryption"]["enabled"] = False
+        metadata["encryption"]["created_at"] = None
+        self._write_metadata(platform, profile_id, metadata)
+
+    # ------------------------------------------------------------------
+    # Profile activation / deactivation
+    # ------------------------------------------------------------------
 
     @staticmethod
     def is_pid_alive(pid: int) -> bool:
         if not pid or pid <= 0:
             return False
         try:
-            os.kill(pid, 0)  # works on Linux, macOS, Windows
+            os.kill(pid, 0)
         except ProcessLookupError:
             return False
         except PermissionError:
             return True
         else:
             return True
-
 
     async def close_profile(self, platform: Platform, profile_id: str, force: bool = False) -> None:
         profile_dir = self.directory.get_profile_dir(platform, profile_id)
@@ -173,12 +314,10 @@ class ProfileManager:
 
         pid = data["status"].get("last_active_pid")
 
-        # Try close via browser layer
         if pid:
             closed = await CamoufoxBrowser.close_browser_by_pid(pid)
 
             if not closed:
-                # If still running and force enabled → kill
                 if force and ProfileManager.is_pid_alive(pid):
                     try:
                         os.kill(pid, signal.SIGTERM)
@@ -189,14 +328,12 @@ class ProfileManager:
                         f"Browser process {pid} still running. Use force=True to terminate."
                     )
 
-        #  Mark inactive
         data["status"]["is_active"] = False
         data["status"]["last_active_pid"] = None
 
         with open(metadata_file, "w") as f:
             json.dump(data, f, indent=4)
 
-        # Remove lock file
         if lock_file.exists():
             lock_file.unlink()
 
@@ -204,14 +341,14 @@ class ProfileManager:
 
     def activate_profile(self, platform: Platform, profile_id: str, browser_obj: CamoufoxBrowser) -> None:
         """
-        Activates a profile. Raises error if already active with a live PID.
+        Activate a profile. Raises if already active with a live PID.
+        Automatically forces headless=True when multiple profiles are running.
         """
-
         profile_dir = self.directory.get_profile_dir(platform, profile_id)
 
         if not profile_dir.exists():
             raise ValueError(
-                f"Profile '{profile_id}' does not exist for platform '{platform}'"
+                f"Profile '{profile_id}' does not exist for platform '{platform}'."
             )
 
         metadata_file = profile_dir / "metadata.json"
@@ -224,7 +361,6 @@ class ProfileManager:
 
         lock_file = profile_dir / ".lock"
 
-        # ----- Active Check -----
         if metadata["status"]["is_active"]:
             pid = metadata["status"]["last_active_pid"]
 
@@ -238,42 +374,34 @@ class ProfileManager:
             if lock_file.exists():
                 lock_file.unlink()
 
-        # ----- Headless override for multi-profile runtime -----
-        # p_count is checked BEFORE __inc__(), so >= 1 means "at least 1 already running"
         if ProfileManager.__p_count__() >= 1:
             browser_obj.config.headless = True
 
         ProfileManager.__inc__()
 
-        # ----- Activate -----
         metadata["status"]["is_active"] = True
         metadata["status"]["last_active_pid"] = os.getpid()
-        metadata["last_used"] = datetime.now().isoformat()
+        metadata["last_used"] = datetime.now(timezone.utc).isoformat()
 
         with open(metadata_file, "w") as f:
             json.dump(metadata, f, indent=4)
 
         lock_file.write_text(str(os.getpid()))
 
-        # TODO: Add distributed / cross-process registry validation (future enhancement)
-
     def delete_profile(self, platform: Platform, profile_id: str, force: bool = False) -> None:
         profile_dir = self.directory.get_profile_dir(platform, profile_id)
 
         if not profile_dir.exists():
-            raise ValueError(f"Profile '{profile_id}' does not exist for platform '{platform}'")
+            raise ValueError(f"Profile '{profile_id}' does not exist for platform '{platform}'.")
 
         metadata_file = profile_dir / "metadata.json"
 
         with open(metadata_file) as f:
             metadata = json.load(f)
 
-        # Block deletion if active
         if metadata["status"]["is_active"] and not force:
             raise ValueError(
                 f"Cannot delete active profile '{profile_id}'. Deactivate first or use force=True."
             )
 
-        # Remove directory safely
         shutil.rmtree(profile_dir)
-

--- a/src/StorageDB/models.py
+++ b/src/StorageDB/models.py
@@ -45,6 +45,11 @@ class Message(Base):
     parent_chat_id: Mapped[str] = mapped_column(
         String(255), nullable=False, default="", index=True
     )
+    # Encrypted versions of chat name (populated when encryption is enabled).
+    # When encrypted_chat_name is set, parent_chat_name holds a HMAC-SHA256
+    # hex digest of the original name (queryable, but not reversible without key).
+    encrypted_chat_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    chat_name_nonce: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # Timing
     system_hit_time: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
@@ -59,9 +64,12 @@ class Message(Base):
     )
 
     def __repr__(self) -> str:
+        chat_label = (
+            "<encrypted>" if self.encrypted_chat_name else self.parent_chat_name
+        )
         return (
             f"<Message(id={self.id}, message_id='{self.message_id}', "
-            f"direction='{self.direction}', chat='{self.parent_chat_name}')>"
+            f"direction='{self.direction}', chat='{chat_label}')>"
         )
 
     def to_dict(self) -> dict:
@@ -76,6 +84,8 @@ class Message(Base):
             "direction": self.direction,
             "parent_chat_name": self.parent_chat_name,
             "parent_chat_id": self.parent_chat_id,
+            "encrypted_chat_name": self.encrypted_chat_name,
+            "chat_name_nonce": self.chat_name_nonce,
             "system_hit_time": self.system_hit_time,
             "created_at": self.created_at.isoformat() if self.created_at else None,
         }

--- a/src/StorageDB/sqlalchemy_storage.py
+++ b/src/StorageDB/sqlalchemy_storage.py
@@ -147,11 +147,11 @@ class SQLAlchemyStorage(StorageInterface):
 
     async def _migrate_add_encryption_columns(self) -> None:
         """
-        Issue 5 fix: Safe migration for users upgrading from v0.1.5.
+        Safe migration for users upgrading from older versions.
 
         SQLAlchemy's create_all() only creates missing tables — it does NOT add
         new columns to existing tables. Users who already have a messages.db
-        from v0.1.5 would get OperationalError without this migration.
+        would get OperationalError without this migration.
 
         Uses 'ALTER TABLE ... ADD COLUMN' with silent error swallowing because
         SQLite does not support 'IF NOT EXISTS' on ADD COLUMN (pre-3.37.0).
@@ -161,6 +161,8 @@ class SQLAlchemyStorage(StorageInterface):
         migration_sqls = [
             "ALTER TABLE messages ADD COLUMN encrypted_message TEXT",
             "ALTER TABLE messages ADD COLUMN encryption_nonce VARCHAR(255)",
+            "ALTER TABLE messages ADD COLUMN encrypted_chat_name TEXT",
+            "ALTER TABLE messages ADD COLUMN chat_name_nonce VARCHAR(255)",
         ]
         async with self._engine.begin() as conn:
             for sql in migration_sqls:
@@ -168,8 +170,7 @@ class SQLAlchemyStorage(StorageInterface):
                     await conn.execute(text(sql))
                     self.log.debug(f"Migration applied: {sql}")
                 except Exception:
-                    # Column already exists — this is expected on fresh installs
-                    pass
+                    pass  # Column already exists — expected on fresh installs
 
     async def start_writer(self, **kwargs) -> None:
         """Start background task to consume queue and write batches."""
@@ -293,9 +294,15 @@ class SQLAlchemyStorage(StorageInterface):
         data_type = getattr(msg, 'data_type', None)
         direction = getattr(msg, 'direction', None)
         system_hit_time = getattr(msg, 'system_hit_time', 0.0)
-        # Issue 4 fix: map the new encryption fields added by the contributor
+
         encrypted_message = getattr(msg, 'encrypted_message', None)
         encryption_nonce = getattr(msg, 'encryption_nonce', None)
+        encrypted_chat_name = getattr(msg, 'encrypted_chat_name', None)
+        chat_name_nonce = getattr(msg, 'chat_name_nonce', None)
+
+        # When encryption is enabled, plaintext and ciphertext must not coexist.
+        if encrypted_message and raw_data:
+            raw_data = ""
 
         parent_chat = getattr(msg, 'parent_chat', None)
         parent_chat_name = ''
@@ -304,11 +311,19 @@ class SQLAlchemyStorage(StorageInterface):
             parent_chat_name = getattr(parent_chat, 'chatName', '') or getattr(parent_chat, 'chat_name', '')
             parent_chat_id = getattr(parent_chat, 'chatID', '') or getattr(parent_chat, 'chat_id', '')
 
+        # When chat name is encrypted, the index column holds an HMAC digest
+        # so queries remain functional without exposing the real name.
+        index_name = getattr(msg, 'parent_chat_name_index', None)
+        if encrypted_chat_name and index_name:
+            parent_chat_name = index_name
+
         return Message(
             message_id=str(message_id),
             raw_data=str(raw_data) if raw_data else '',
             encrypted_message=encrypted_message,
             encryption_nonce=encryption_nonce,
+            encrypted_chat_name=encrypted_chat_name,
+            chat_name_nonce=chat_name_nonce,
             data_type=str(data_type) if data_type else None,
             direction=str(direction) if direction else None,
             parent_chat_name=str(parent_chat_name),
@@ -379,7 +394,7 @@ class SQLAlchemyStorage(StorageInterface):
                 return []
 
     async def get_messages_by_chat(self, chat_name: str, **kwargs) -> List[Dict[str, Any]]:
-        """Get messages filtered by chat name."""
+        """Get messages filtered by chat name (or HMAC digest if encryption is enabled)."""
         if not self._session_factory:
             return []
 
@@ -400,6 +415,81 @@ class SQLAlchemyStorage(StorageInterface):
             except Exception as e:
                 self.log.error(f"Get messages by chat failed: {e}")
                 return []
+
+    async def get_decrypted_messages_async(
+        self,
+        key: bytes,
+        limit: int = 1000,
+        offset: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """
+        Fetch all messages and decrypt body + chat name on-the-fly.
+
+        This is the primary way a user retrieves readable messages when
+        encryption is enabled.  Pass the key from
+        ``ProfileManager.get_key(platform, profile_id)``.
+
+        Args:
+            key:    Raw 32-byte AES-256 key (from ProfileManager.get_key).
+            limit:  Max rows to fetch.
+            offset: Pagination offset.
+
+        Returns:
+            List of dicts identical to ``to_dict()`` but with:
+            - ``raw_data`` populated with decrypted plaintext (or original value
+              when the row was stored without encryption).
+            - ``parent_chat_name`` populated with decrypted chat name (or the
+              HMAC digest / original value when not encrypted).
+
+        Example::
+
+            key = manager.get_key(Platform.WHATSAPP, "my_profile")
+            rows = await storage.get_decrypted_messages_async(key)
+        """
+        import base64 as _b64
+        from src.Encryption import MessageDecryptor, KeyManager
+        import hashlib as _hashlib
+
+        rows = await self.get_all_messages_async(limit=limit, offset=offset)
+
+        decryptor = MessageDecryptor(key)
+        # Re-derive the HMAC sub-key used for chat-name indexing
+        hmac_key = _hashlib.sha256(key + b"chat-name-index").digest()[:16]
+
+        result = []
+        for row in rows:
+            out = dict(row)
+
+            # Decrypt message body
+            enc_msg = row.get("encrypted_message")
+            enc_nonce = row.get("encryption_nonce")
+            if enc_msg and enc_nonce:
+                try:
+                    nonce_bytes = _b64.b64decode(enc_nonce)
+                    cipher_bytes = _b64.b64decode(enc_msg)
+                    msg_id = row.get("message_id", "")
+                    out["raw_data"] = decryptor.decrypt_message(
+                        nonce_bytes, cipher_bytes, msg_id or None
+                    )
+                except Exception as e:
+                    self.log.warning(f"Failed to decrypt message {row.get('message_id')}: {e}")
+                    out["raw_data"] = "<decryption failed>"
+
+            # Decrypt chat name
+            enc_chat = row.get("encrypted_chat_name")
+            chat_nonce = row.get("chat_name_nonce")
+            if enc_chat and chat_nonce:
+                try:
+                    nonce_bytes = _b64.b64decode(chat_nonce)
+                    cipher_bytes = _b64.b64decode(enc_chat)
+                    out["parent_chat_name"] = decryptor.decrypt(nonce_bytes, cipher_bytes)
+                except Exception as e:
+                    self.log.warning(f"Failed to decrypt chat name: {e}")
+                    out["parent_chat_name"] = "<decryption failed>"
+
+            result.append(out)
+
+        return result
 
     def _get_session_factory(self) -> async_sessionmaker[AsyncSession]:
         if self._session_factory is None:
@@ -428,7 +518,7 @@ class SQLAlchemyStorage(StorageInterface):
         """Async context manager entry."""
         await self.init_db()
         await self.create_table()
-        await self._migrate_add_encryption_columns()  # Issue 5 fix: safe upgrade migration
+        await self._migrate_add_encryption_columns()
         await self.start_writer()
         return self
 

--- a/src/WhatsApp/DerivedTypes/Message.py
+++ b/src/WhatsApp/DerivedTypes/Message.py
@@ -25,8 +25,17 @@ class whatsapp_message:
     data_type: Optional[str] = None
     message_id: str = field(init=False)
     system_hit_time: float = field(default_factory=time.time)
+
+    # Message body encryption (set by MessageProcessor when encryption is enabled)
     encrypted_message: Optional[str] = None
     encryption_nonce: Optional[str] = None
+
+    # Chat name encryption (set by MessageProcessor when encryption is enabled)
+    # encrypted_chat_name / chat_name_nonce: AES-256-GCM ciphertext of the real chat name
+    # parent_chat_name_index: HMAC-SHA256 hex digest used as the queryable DB index value
+    encrypted_chat_name: Optional[str] = None
+    chat_name_nonce: Optional[str] = None
+    parent_chat_name_index: Optional[str] = None  # replaces plaintext in DB when encrypted
 
     def isIncoming(self) -> Optional[bool]:
         """

--- a/src/WhatsApp/humanized_operations.py
+++ b/src/WhatsApp/humanized_operations.py
@@ -90,7 +90,7 @@ class HumanizedOperations(HumanizeOperationInterface):
         """
 
         loop = asyncio.get_running_loop()
-
+        previous_clipboard: Optional[str] = None
         async with _clipboard_async_lock:
             # Acquire OS-level file lock in executor (blocking operation)
             await loop.run_in_executor(None, _clipboard_file_lock.acquire)
@@ -111,8 +111,8 @@ class HumanizedOperations(HumanizeOperationInterface):
                 await self.page.keyboard.press("Control+V")
             finally:
                 # Restore previous clipboard content
-                if previous_clipboard:
+                if previous_clipboard is not None:
                     await loop.run_in_executor(
                         None, pyperclip.copy, previous_clipboard
                     )
-                _clipboard_file_lock.release()
+                await loop.run_in_executor(None, _clipboard_file_lock.release)

--- a/src/WhatsApp/message_processor.py
+++ b/src/WhatsApp/message_processor.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-import logging
 import base64
+import hashlib
+import hmac
+import logging
 from typing import List, Optional, Sequence
 
 from playwright.async_api import Page
@@ -25,7 +27,21 @@ from src.WhatsApp.web_ui_config import WebSelectorConfig
 
 
 class MessageProcessor(MessageProcessorInterface):
-    """Extracts and processes messages from WhatsApp Web UI."""
+    """Extracts, encrypts (optionally), and stores messages from WhatsApp Web UI.
+
+    Encryption behaviour
+    --------------------
+    When an ``encryption_key`` is supplied:
+
+    - Message body (``raw_data``) is encrypted with AES-256-GCM and the
+      plaintext is blanked, so ciphertext and plaintext never coexist in
+      the same database row.
+    - Chat name (``parent_chat_name``) is encrypted with AES-256-GCM; the
+      database index column stores a stable HMAC-SHA256 digest instead of
+      the real name, keeping queries functional without exposing it.
+    - The raw key is deleted from memory immediately after the encryptor is
+      initialised.
+    """
 
     def __init__(
         self,
@@ -45,23 +61,51 @@ class MessageProcessor(MessageProcessorInterface):
             UIConfig=UIConfig,
         )
         self.chat_processor = chat_processor
-        # Bug 3 fix: never persist raw key on self — initialise encryptor then discard
+
         self.encryptor = None
+        self._hmac_key: Optional[bytes] = None
 
         if encryption_key:
             try:
                 from src.Encryption import MessageEncryptor
 
                 self.encryptor = MessageEncryptor(encryption_key)
-                self.log.info("Message encryption enabled")
+                self._hmac_key = hashlib.sha256(encryption_key + b"chat-name-index").digest()[:16]
+                self.log.info("Message encryption enabled (body + chat name).")
             except Exception as e:
-                self.log.error(f"Failed to initialize encryptor: {e}")
+                self.log.error(f"Failed to initialise encryptor: {e}")
                 self.encryptor = None
+                self._hmac_key = None
             finally:
-                del encryption_key  # wipe raw key from memory immediately
+                del encryption_key
 
         if self.page is None:
             raise ValueError("page must not be None")
+
+    def _hmac_chat_name(self, chat_name: str) -> str:
+        """Return a stable HMAC-SHA256 hex digest of the chat name.
+
+        Used as the queryable ``parent_chat_name`` index value when encryption
+        is enabled — the real name is stored encrypted in ``encrypted_chat_name``.
+        """
+        assert self._hmac_key is not None
+        return hmac.new(  # type: ignore[attr-defined]
+            self._hmac_key, chat_name.encode("utf-8"), hashlib.sha256
+        ).hexdigest()
+
+    def _encrypt_chat_name(self, chat_name: str) -> tuple[str, str, str]:
+        """Encrypt chat name.
+
+        Returns:
+            Tuple of (hmac_digest, b64_ciphertext, b64_nonce).
+        """
+        assert self.encryptor is not None
+        nonce, ciphertext = self.encryptor.encrypt(chat_name)
+        return (
+            self._hmac_chat_name(chat_name),
+            base64.b64encode(ciphertext).decode("utf-8"),
+            base64.b64encode(nonce).decode("utf-8"),
+        )
 
     @staticmethod
     async def sort_messages(
@@ -105,9 +149,7 @@ class MessageProcessor(MessageProcessorInterface):
                     c2 += 1
 
                 if not data_id:
-                    self.log.debug(
-                        "Data ID in WA / get wrapped Messages , None/Empty. Skipping"
-                    )
+                    self.log.debug("Data ID is None/Empty — skipping message.")
                     continue
 
                 wrapped_list.append(
@@ -129,44 +171,42 @@ class MessageProcessor(MessageProcessorInterface):
     async def Fetcher(
         self, chat: whatsapp_chat, retry: int, *args, **kwargs
     ) -> List[whatsapp_message]:
-        """Fetch, store, and filter messages from a chat."""
+        """Fetch, optionally encrypt, store, and filter messages from a chat."""
         msgList = await self._get_wrapped_Messages(chat, retry, *args, **kwargs)
 
         if self.storage and msgList:
-            # Bug 1 fix: use async version — check_message_if_exists uses asyncio.run()
-            # which raises RuntimeError when called from inside a running event loop.
             new_msgs = [
                 msg
                 for msg in msgList
                 if not await self.storage.check_message_if_exists_async(msg.message_id)
             ]
             if new_msgs:
-                # Encrypt messages if encryption is enabled
                 if self.encryptor:
-                    for msg in new_msgs:
-                        try:
-                            # Bug 2 fix: skip encryption for media/empty messages
-                            # where raw_data is None (images, stickers, voice notes)
-                            raw = msg.raw_data or ""
-                            if not raw:
-                                self.log.debug(
-                                    f"Skipping encryption for non-text message {msg.message_id}"
-                                )
-                                continue
+                    chat_name = chat.chat_name
+                    chat_hmac, enc_chat_b64, chat_nonce_b64 = self._encrypt_chat_name(chat_name)
 
-                            nonce, ciphertext = self.encryptor.encrypt_message(
-                                raw, msg.message_id
+                    for msg in new_msgs:
+                        raw = msg.raw_data or ""
+                        if raw:
+                            try:
+                                nonce, ciphertext = self.encryptor.encrypt_message(
+                                    raw, msg.message_id
+                                )
+                                msg.encrypted_message = base64.b64encode(ciphertext).decode("utf-8")
+                                msg.encryption_nonce = base64.b64encode(nonce).decode("utf-8")
+                                msg.raw_data = ""
+                            except Exception as e:
+                                self.log.warning(
+                                    f"Failed to encrypt message {msg.message_id}: {e}"
+                                )
+                        else:
+                            self.log.debug(
+                                f"Skipping body encryption for non-text message {msg.message_id}"
                             )
-                            msg.encrypted_message = base64.b64encode(ciphertext).decode(
-                                "utf-8"
-                            )
-                            msg.encryption_nonce = base64.b64encode(nonce).decode(
-                                "utf-8"
-                            )
-                        except Exception as e:
-                            self.log.warning(
-                                f"Failed to encrypt message {msg.message_id}: {e}"
-                            )
+
+                        msg.encrypted_chat_name = enc_chat_b64
+                        msg.chat_name_nonce = chat_nonce_b64
+                        msg.parent_chat_name_index = chat_hmac
 
                 await self.storage.enqueue_insert(new_msgs)
                 self.log.debug(

--- a/src/WhatsApp/web_ui_config.py
+++ b/src/WhatsApp/web_ui_config.py
@@ -185,8 +185,7 @@ class WebSelectorConfig(WebUISelectorCapable):
             if message_element is None:
                 return ""
 
-        # OLD: span.selectable-text.copyable-text (Class 'selectable-text' removed in recent WA updates)
-        # NEW: span[data-testid="selectable-text"] OR span.copyable-text
+
         span = await message_element.query_selector("span[data-testid='selectable-text']")
         if not span:
             # Fallback to inner_text directly if span not found
@@ -197,8 +196,6 @@ class WebSelectorConfig(WebUISelectorCapable):
             return text or ""
         return ""
 
-    # def get_message_text(element: Locator | ElementHandle) -> str:
-    #     return element.inner_text().strip()
 
     @staticmethod
     async def is_message_out(message: Union[ElementHandle, Locator]) -> bool:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,7 +1,18 @@
-"""tweakio-sdk - WhatsApp automation library."""
+"""camouchat — Anti-detection WhatsApp automation SDK."""
 
-__version__ = "0.1.5"
+__version__ = "0.6"
 
-from .BrowserManager import BrowserManager
 
-__all__ = ['BrowserManager']
+from .BrowserManager import ProfileManager, ProfileInfo, Platform, CamoufoxBrowser, BrowserConfig
+from .Encryption import MessageEncryptor, MessageDecryptor, KeyManager
+
+__all__ = [
+    "ProfileManager",
+    "ProfileInfo",
+    "Platform",
+    "CamoufoxBrowser",
+    "BrowserConfig",
+    "MessageEncryptor",
+    "MessageDecryptor",
+    "KeyManager",
+]

--- a/src/directory.py
+++ b/src/directory.py
@@ -6,7 +6,7 @@ from platformdirs import PlatformDirs
 class DirectoryManager:
     """Manages application-wide and profile-specific directory structures."""
 
-    def __init__(self, app_name: str = "Tweakio_sdk"):
+    def __init__(self, app_name: str = "CamouChat"):
         """Initialize DirectoryManager with an application name."""
         self.dirs = PlatformDirs(
             appname=app_name,
@@ -39,6 +39,18 @@ class DirectoryManager:
     def get_database_path(self, platform: str, profile_id: str) -> Path:
         """Returns the path to the messages database for a profile."""
         return self.get_profile_dir(platform, profile_id) / "messages.db"
+
+    def get_key_file_path(self, platform: str, profile_id: str) -> Path:
+        """
+        Returns the path to the encryption key file for a profile.
+
+        The key file is separate from metadata.json intentionally — metadata.json
+        is a general-purpose readable file. The key file is a dedicated secret
+        that only ProfileManager touches when encryption is enabled.
+
+        File format: raw base64-encoded 32-byte AES-256 key (single line, no newline).
+        """
+        return self.get_profile_dir(platform, profile_id) / "encryption.key"
 
     def get_error_trace_file(self) -> Path:
         """Returns the path to the global ErrorTrace log file."""

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "apify-fingerprint-datapoints"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -60,6 +69,58 @@ sdist = { url = "https://files.pythonhosted.org/packages/78/6f/8975af88d203efd70
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/35/ce962f738ae28ffce6293e7607b129075633e6bb185a5ab87e49246eedc2/browserforge-1.2.4-py3-none-any.whl", hash = "sha256:fb1c14e62ac09de221dcfc73074200269f697596c642cb200ceaab1127a17542", size = 37890, upload-time = "2026-02-03T02:52:08.745Z" },
 ]
+
+[[package]]
+name = "camouchat"
+version = "0.6"
+source = { editable = "." }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "browserforge" },
+    { name = "camoufox" },
+    { name = "colorlog" },
+    { name = "cryptography" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "playwright" },
+    { name = "pyperclip" },
+    { name = "sqlalchemy" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "black" },
+    { name = "deptry" },
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.19.0" },
+    { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
+    { name = "browserforge", specifier = ">=1.2.4" },
+    { name = "camoufox", specifier = ">=0.3.0" },
+    { name = "colorlog", specifier = ">=6.10.1" },
+    { name = "cryptography", specifier = ">=41.0.0" },
+    { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.16.0" },
+    { name = "filelock", specifier = ">=3.13.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
+    { name = "platformdirs", specifier = ">=4.0.0" },
+    { name = "playwright", specifier = ">=1.40.0" },
+    { name = "pyperclip", specifier = ">=1.8.2" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.11.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.0.290" },
+    { name = "sqlalchemy", specifier = ">=2.0.48" },
+]
+provides-extras = ["dev"]
 
 [[package]]
 name = "camoufox"
@@ -476,6 +537,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/03/c7/c3180784855e702aa5fa94c88a4bda3c5364860606dccc13ba86bf45ee90/deptry-0.24.0-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:5152ffa478e62f9aea9df585ce49d758087fd202f6d92012216aa0ecad22c267", size = 1957564, upload-time = "2025-11-09T00:31:32.285Z" },
     { url = "https://files.pythonhosted.org/packages/e9/65/f33e882d743eda90a7f12515f774be08bdf244520298d259ed9be687e5fe/deptry-0.24.0-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:68d90735042c169e2a12846ac5af9e20d0ad1a5a7a894a9e4eb0bd8f3c655add", size = 2019800, upload-time = "2025-11-09T00:31:37.625Z" },
     { url = "https://files.pythonhosted.org/packages/18/b8/68d6ca1d8a16061e79693587560f6d24ac18ba9617804d7808b2c988d9d5/deptry-0.24.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:03d375db3e56821803aeca665dbb4c2fd935024310350cc18e8d8b6421369d2b", size = 1629786, upload-time = "2025-11-09T00:31:49.469Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8b/4c32ecde6bea6486a2a5d05340e695174351ff6b06cf651a74c005f9df00/filelock-3.25.1.tar.gz", hash = "sha256:b9a2e977f794ef94d77cdf7d27129ac648a61f585bff3ca24630c1629f701aa9", size = 40319, upload-time = "2026-03-09T19:38:47.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/b8/2f664b56a3b4b32d28d3d106c71783073f712ba43ff6d34b9ea0ce36dc7b/filelock-3.25.1-py3-none-any.whl", hash = "sha256:18972df45473c4aa2c7921b609ee9ca4925910cc3a0fb226c96b92fc224ef7bf", size = 26720, upload-time = "2026-03-09T19:38:45.718Z" },
 ]
 
 [[package]]
@@ -1388,54 +1458,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
-
-[[package]]
-name = "tweakio-sdk"
-version = "0.1.5"
-source = { editable = "." }
-dependencies = [
-    { name = "browserforge" },
-    { name = "camoufox" },
-    { name = "colorlog" },
-    { name = "cryptography" },
-    { name = "platformdirs" },
-    { name = "playwright" },
-    { name = "pyperclip" },
-    { name = "sqlalchemy" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "black" },
-    { name = "deptry" },
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-mock" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
-    { name = "browserforge", specifier = ">=1.2.4" },
-    { name = "camoufox", specifier = ">=0.3.0" },
-    { name = "colorlog", specifier = ">=6.10.1" },
-    { name = "cryptography", specifier = ">=41.0.0" },
-    { name = "deptry", marker = "extra == 'dev'", specifier = ">=0.16.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
-    { name = "platformdirs", specifier = ">=4.0.0" },
-    { name = "playwright", specifier = ">=1.40.0" },
-    { name = "pyperclip", specifier = ">=1.8.2" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
-    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.11.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.0.290" },
-    { name = "sqlalchemy", specifier = ">=2.0.48" },
-]
-provides-extras = ["dev"]
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
- Rename package: tweakio-sdk → camouchat (v0.6)
- Add ProfileManager.enable_encryption() / get_key() / disable_encryption() with secure key storage in per-profile encryption.key file (chmod 0600)
- Add DirectoryManager.get_key_file_path() for sandboxed key location
- Encrypt chat names (AES-256-GCM) alongside message bodies; store HMAC-SHA256 digest as queryable DB index instead of plaintext
- Fix plaintext leak: raw_data is blanked when encrypted_message is set
- Add encrypted_chat_name + chat_name_nonce columns to Message model
- Add safe DB migration for new encryption columns
- Add SQLAlchemyStorage.get_decrypted_messages_async() for key-based fetch
- Add aiosqlite as explicit dependency
- Update pyproject.toml: full SEO keywords, PyPI classifiers, project URLs
- Slim setup.py to a minimal shim (pyproject.toml is single source of truth)
- Fix broken src/__init__.py import (BrowserManager class never existed)
- Fix humanized_operations.py: previous_clipboard init + async lock release
- Cleanup: remove dev-note inline comments across codebase


closes #108  

