### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main", "master"]


### PR DESCRIPTION
Potential fix for [https://github.com/BITS-Rohit/tweakio-sdk/security/code-scanning/3](https://github.com/BITS-Rohit/tweakio-sdk/security/code-scanning/3)

In general, the fix is to explicitly define a `permissions` block that limits the `GITHUB_TOKEN` to the minimal scopes required. Since these jobs only check out code and run local tooling, they only need read access to the repository contents, and potentially `id-token: write` if they were using OIDC (they are not here). The Codecov action is already configured with an explicit `token: ${{ secrets.CODECOV_TOKEN }}`, so it does not need `GITHUB_TOKEN` write permissions either.

The best fix without changing existing functionality is to add a single top‑level `permissions` block to `.github/workflows/ci.yml`, right under the `name: CI` line, so that it applies to all jobs. This block should at least set `contents: read`. No other permissions appear to be necessary from the provided snippet. No extra imports or methods are required; this is a pure YAML configuration change.

Concretely:
- Edit `.github/workflows/ci.yml`.
- Insert a new `permissions:` mapping after line 1 (`name: CI`) and before the `on:` block.
- Set it to:
  ```yaml
  permissions:
    contents: read
  ```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
