### PR TITLE
refactor: whatsApp Login Client to Decouple Web Selectors

### DIFF
--- a/camouchat/WhatsApp/login.py
+++ b/camouchat/WhatsApp/login.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 from logging import Logger, LoggerAdapter
 import random
-import re
 
 import weakref
 from playwright.async_api import Page, TimeoutError as PlaywrightTimeoutError, Locator
@@ -110,7 +109,7 @@ class Login(LoginInterface):
 
         self.log.info("Starting code-based login...")
 
-        btn = self.page.get_by_role("button", name=re.compile("log.*in.*phone number", re.I))
+        btn = self.UIConfig.link_phone_number_button()
         if await btn.count() == 0:
             raise LoginError("Login-with-phone-number button not found.")
 
@@ -120,7 +119,7 @@ class Login(LoginInterface):
         except PlaywrightTimeoutError as e:
             raise LoginError("Failed to open phone login screen.") from e
 
-        ctl = self.page.locator("button:has(span[data-icon='chevron'])")
+        ctl = self.UIConfig.country_selector_button()
         if await ctl.count() == 0:
             raise LoginError("Country selector not found.")
 
@@ -128,7 +127,7 @@ class Login(LoginInterface):
         await self.page.keyboard.type(country, delay=random.randint(80, 120))
         await asyncio.sleep(1)
 
-        countries: Locator = self.page.get_by_role("listitem").locator("button")
+        countries: Locator = self.UIConfig.country_list_items()
         if await countries.count() == 0:
             raise LoginError(f"No countries found for input: {country}")
 
@@ -150,14 +149,14 @@ class Login(LoginInterface):
         if not selected:
             raise LoginError(f"Country '{country}' not selectable.")
 
-        inp = self.page.locator("form >> input")
+        inp = self.UIConfig.phone_number_input()
         if await inp.count() == 0:
             raise LoginError("Phone number input not found.")
 
         await inp.type(str(number), delay=random.randint(80, 120))
         await self.page.keyboard.press("Enter")
 
-        code_el = self.page.locator("div[data-link-code]")
+        code_el = self.UIConfig.link_code_container()
         try:
             await code_el.wait_for(timeout=10_000)
             code = await code_el.get_attribute("data-link-code")

--- a/camouchat/WhatsApp/web_ui_config.py
+++ b/camouchat/WhatsApp/web_ui_config.py
@@ -145,6 +145,26 @@ class WebSelectorConfig(WebUISelectorCapable):
         """Returns the QR canvas image for login."""
         return self.page.get_by_role("img", name=re.compile(r"scan.*qr", re.I))
 
+    def link_phone_number_button(self) -> Locator:
+        """Returns the locator for 'Link with phone number' button."""
+        return self.page.get_by_role("button", name=re.compile(r"log.*in.*phone number", re.I))
+
+    def country_selector_button(self) -> Locator:
+        """Returns the locator for country selection dropdown (chevron icon)."""
+        return self.page.locator("button:has(span[data-icon='chevron'])")
+
+    def country_list_items(self) -> Locator:
+        """Returns the locator for country items in the list."""
+        return self.page.get_by_role("listitem").locator("button")
+
+    def phone_number_input(self) -> Locator:
+        """Returns the locator for phone number input field."""
+        return self.page.locator("form >> input")
+
+    def link_code_container(self) -> Locator:
+        """Returns the locator for the link code display."""
+        return self.page.locator("div[data-link-code]")
+
     # -------------------- Sidebar Navigation -------------------- #
 
     def _side_Bar_chats(self) -> Locator:

--- a/tests/unit/WhatsApp/test_Login.py
+++ b/tests/unit/WhatsApp/test_Login.py
@@ -145,15 +145,15 @@ async def test_code_login_missing_args(login_instance, tmp_path):
 async def test_code_login_success(login_instance, tmp_path):
     """Test code-based login full flow."""
     # Setup Mocks for UI interaction sequence
-    mock_page = login_instance.page
 
     # 1. Phone login button
     mock_role_btn = AsyncMock(spec=Locator)
-    mock_page.get_by_role.return_value = mock_role_btn
     mock_role_btn.count.return_value = 1
+    login_instance.UIConfig.link_phone_number_button.return_value = mock_role_btn
 
     # 2. Country selector
     mock_chevron = AsyncMock(spec=Locator)
+    login_instance.UIConfig.country_selector_button.return_value = mock_chevron
 
     # 3. Country list items
     mock_countries = AsyncMock(spec=Locator)
@@ -161,37 +161,18 @@ async def test_code_login_success(login_instance, tmp_path):
     mock_country_item = AsyncMock(spec=Locator)
     mock_country_item.inner_text.return_value = "India"
     mock_countries.nth.return_value = mock_country_item
+    login_instance.UIConfig.country_list_items.return_value = mock_countries
 
-    mock_listitem = AsyncMock(spec=Locator)
-    mock_listitem.locator.return_value = mock_countries
-
-    def get_by_role_side_effect(role, name=None):
-        if role == "button" and name:
-            return mock_role_btn
-        if role == "listitem":
-            return mock_listitem
-        return AsyncMock()
-
-    mock_page.get_by_role.side_effect = get_by_role_side_effect
-
-    # 4. Phone Input (using locator "form >> input")
+    # 4. Phone Input
     mock_input = AsyncMock(spec=Locator)
     mock_input.count.return_value = 1
+    login_instance.UIConfig.phone_number_input.return_value = mock_input
 
     # 5. Code element
     mock_code_el = AsyncMock(spec=Locator)
+    mock_code_el.wait_for = AsyncMock()
     mock_code_el.get_attribute.return_value = "ABC-123"
-
-    def locator_side_effect(sel):
-        if "chevron" in sel:
-            return mock_chevron
-        if "form >> input" in sel:
-            return mock_input
-        if "data-link-code" in sel:
-            return mock_code_el
-        return AsyncMock()
-
-    mock_page.locator.side_effect = locator_side_effect
+    login_instance.UIConfig.link_code_container.return_value = mock_code_el
 
     # Execution
     result = await login_instance.login(
@@ -235,7 +216,7 @@ async def test_code_login_btn_missing(login_instance, tmp_path):
     """Test failure when phone login button is missing."""
     mock_role_btn = AsyncMock(spec=Locator)
     mock_role_btn.count.return_value = 0  # Button not found
-    login_instance.page.get_by_role.return_value = mock_role_btn
+    login_instance.UIConfig.link_phone_number_button.return_value = mock_role_btn
 
     with pytest.raises(LoginError, match="Login-with-phone-number button not found"):
         await login_instance.login(
@@ -248,11 +229,11 @@ async def test_code_login_country_missing(login_instance, tmp_path):
     """Test failure when country selector not found."""
     mock_role_btn = AsyncMock(spec=Locator)
     mock_role_btn.count.return_value = 1
-    login_instance.page.get_by_role.return_value = mock_role_btn
+    login_instance.UIConfig.link_phone_number_button.return_value = mock_role_btn
 
     mock_chevron = AsyncMock(spec=Locator)
     mock_chevron.count.return_value = 0  # Selector missing
-    login_instance.page.locator.return_value = mock_chevron
+    login_instance.UIConfig.country_selector_button.return_value = mock_chevron
 
     with pytest.raises(LoginError, match="Country selector not found"):
         await login_instance.login(
@@ -273,7 +254,7 @@ async def test_code_login_timeout(login_instance, tmp_path):
     mock_role_btn = AsyncMock(spec=Locator)
     mock_role_btn.count.return_value = 1
     mock_role_btn.click.side_effect = PlaywrightTimeoutError("Bust")
-    login_instance.page.get_by_role.return_value = mock_role_btn
+    login_instance.UIConfig.link_phone_number_button.return_value = mock_role_btn
 
     with pytest.raises(LoginError, match="Failed to open phone login screen"):
         await login_instance.login(

--- a/tests/unit/WhatsApp/test_Web_UI_Config.py
+++ b/tests/unit/WhatsApp/test_Web_UI_Config.py
@@ -3,6 +3,7 @@ Unit tests for WebSelectorConfig class.
 Tests cover locator construction and static helper methods.
 """
 
+import re
 from unittest.mock import Mock, AsyncMock
 
 import pytest
@@ -114,3 +115,38 @@ async def test_is_message_out_locator(config_instance):
 
     result = await WebSelectorConfig.is_message_out(mock_msg)
     assert result is True
+
+
+@pytest.mark.asyncio
+async def test_link_phone_number_button(config_instance):
+    config_instance.link_phone_number_button()
+    config_instance.page.get_by_role.assert_called_with(
+        "button", name=re.compile(r"log.*in.*phone number", re.I)
+    )
+
+
+@pytest.mark.asyncio
+async def test_country_selector_button(config_instance):
+    config_instance.country_selector_button()
+    config_instance.page.locator.assert_called_with("button:has(span[data-icon='chevron'])")
+
+
+@pytest.mark.asyncio
+async def test_country_list_items(config_instance):
+    mock_listitem = AsyncMock(spec=Locator)
+    config_instance.page.get_by_role.return_value = mock_listitem
+    config_instance.country_list_items()
+    config_instance.page.get_by_role.assert_called_with("listitem")
+    mock_listitem.locator.assert_called_with("button")
+
+
+@pytest.mark.asyncio
+async def test_phone_number_input(config_instance):
+    config_instance.phone_number_input()
+    config_instance.page.locator.assert_called_with("form >> input")
+
+
+@pytest.mark.asyncio
+async def test_link_code_container(config_instance):
+    config_instance.link_code_container()
+    config_instance.page.locator.assert_called_with("div[data-link-code]")


### PR DESCRIPTION
## Description
Refactored the WhatsApp login client to decouple web selector dependencies from the core business logic. UI element definitions for the phone number login flow have been moved from `login.py` to the `WebSelectorConfig` object in `web_ui_config.py`. This ensures a cleaner, more maintainable structure where the login client focuses purely on business logic.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring

## Related Issues
Fixes #87

## Changes Made
- **Refactored `camouchat/WhatsApp/login.py`**: Removed direct Playwright `page` locator calls (e.g., `get_by_role`, `locator`) in `__code_login` and replaced them with calls to `self.UIConfig` methods.
- **Enhanced `camouchat/WhatsApp/web_ui_config.py`**: Added 5 new methods to `WebSelectorConfig` to centralize UI selectors for phone number login:
    - `link_phone_number_button()`
    - `country_selector_button()`
    - `country_list_items()`
    - `phone_number_input()`
    - `link_code_container()`
- **Updated `tests/unit/WhatsApp/test_Login.py`**: Refactored existing tests to mock `WebSelectorConfig` methods instead of direct Playwright interactions, ensuring tests remain robust after the refactor.
- **Updated `tests/unit/WhatsApp/test_Web_UI_Config.py`**: Added comprehensive unit tests for all new selector methods added to `WebSelectorConfig`.

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have tested this change manually

## Testing Details
Verified all changes using `pytest` within the project's recommended `uv` environment.
```bash
# Run unit tests for Login and WebSelectorConfig
uv run --all-extras pytest -v tests/unit/WhatsApp/test_Login.py tests/unit/WhatsApp/test_Web_UI_Config.py

# Verify code formatting and linting
uv run black camouchat/WhatsApp/login.py camouchat/WhatsApp/web_ui_config.py tests/unit/WhatsApp/test_Login.py tests/unit/WhatsApp/test_Web_UI_Config.py
uv run ruff check camouchat/WhatsApp/login.py camouchat/WhatsApp/web_ui_config.py tests/unit/WhatsApp/test_Login.py tests/unit/WhatsApp/test_Web_UI_Config.py
```

## Documentation
- [ ] I have updated the documentation accordingly
- [x] I have added docstrings to new functions/classes
- [ ] I have updated the README if needed

## Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Additional Notes
The refactoring maintains exactly the same logical flow for WhatsApp login to ensure no regression in core functionality. The changes strictly follow the requirements of issue #87 for structural enhancement.